### PR TITLE
Fix initial map bound setting

### DIFF
--- a/src/views/sfMap/constants.ts
+++ b/src/views/sfMap/constants.ts
@@ -1,8 +1,11 @@
+import { LngLatBounds } from "mapbox-gl";
+
 // Center view around San Francisco
 export const mapInitialViewState = {
-  longitude: -122.45,
-  latitude: 37.778,
-  zoom: 13,
+  bounds: new LngLatBounds(
+    { lon: -122.514239, lat: 37.732597 },
+    { lon: -122.383097, lat: 37.815894 }
+  ),
 };
 
 export const shadow =


### PR DESCRIPTION
Follow-up to #12 

Make sure bounds are set around SF on initial load, regardless of screen size.