### PR TITLE
Add touch-ups

### DIFF
--- a/src/components/bubbles/Scene.js
+++ b/src/components/bubbles/Scene.js
@@ -59,6 +59,7 @@ const Scene = ({ onCreated, isSceneReady }) => {
         position: absolute;
         user-select: none;
         touch-action: none;
+        cursor: pointer;
         height: 100%;
         width: 100%;
         transition: opacity 300ms ease-in-out;

--- a/src/pages/pale-blue-dot.tsx
+++ b/src/pages/pale-blue-dot.tsx
@@ -61,8 +61,8 @@ const PaleBlueDot = () => (
           sx={{
             display: "flex",
             position: "relative",
-            height: "624px",
             mb: 1,
+            aspectRatio: "1 / 1",
           }}
         >
           <Image


### PR DESCRIPTION
Make Pale Blue Dot page not too long on mobile.

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/2905455/224527706-9fdcceb4-ad31-4bae-b893-a8a7bd3873f0.png">

Add a cursor to main page to indicate that it's clickable.
