### PR TITLE
2023-10-17 Customize Tailwind typography

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,13 @@
 import { Metadata } from "next";
+import { IBM_Plex_Mono } from "next/font/google";
 import { Providers } from "./providers";
 import "../styles/global.css";
+
+const plexMono = IBM_Plex_Mono({
+  weight: ["400", "500"],
+  subsets: ["latin"],
+  variable: "--font-plex-mono",
+});
 
 export const metadata: Metadata = {
   title: "Andrew Ho",
@@ -18,7 +25,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning className={plexMono.variable}>
       <head>
         <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
       </head>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,6 +27,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning className={plexMono.variable}>
       <head>
+        <link rel="preconnect" href="https://rsms.me/" />
         <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
       </head>
       <body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { IBM_Plex_Mono } from "next/font/google";
 import { Providers } from "./providers";
 import "../styles/global.css";
 
+// Inter isn't imported like this because the left and right arrows aren't
+// included in the subset.
 const plexMono = IBM_Plex_Mono({
   weight: ["400", "500"],
   subsets: ["latin"],

--- a/src/components/postBody.tsx
+++ b/src/components/postBody.tsx
@@ -1,13 +1,41 @@
 import Markdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
+import classNames from "classnames";
 
 type Props = {
   content: string;
 };
 
+const codeClasses =
+  "prose-code:rounded prose-code:bg-gray-3 prose-code:font-medium prose-code:[font-size:87.5%]";
+
+const preClasses = "prose-pre:rounded-2xl";
+
+const imageClasses = "prose-img:rounded-2xl";
+
+const horizontalRuleClasses =
+  "prose-hr:mx-auto prose-hr:my-16 prose-hr:w-1/3 prose-hr:border prose-hr:border-t-0 prose-hr:border-gray-6";
+
+const linkClasses =
+  "prose-a:no-underline hover:prose-a:underline focus:prose-a:underline active:prose-a:underline";
+
+const blockquoteClasses = classNames(
+  "prose-blockquote:not-italic prose-blockquote:relative prose-blockquote:text-gray-11 prose-blockquote:font-normal before:prose-blockquote:absolute before:prose-blockquote:left-0 before:prose-blockquote:w-1 before:prose-blockquote:h-full before:prose-blockquote:rounded before:prose-blockquote:bg-gray-7",
+);
+
 const PostBody = ({ content }: Props) => (
-  <div className="prose dark:prose-invert">
+  <div
+    className={classNames(
+      "prose-custom prose max-w-none",
+      codeClasses,
+      preClasses,
+      imageClasses,
+      horizontalRuleClasses,
+      linkClasses,
+      blockquoteClasses,
+    )}
+  >
     <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
       {content}
     </Markdown>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,8 +32,9 @@
     "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue",
     "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
     "Segoe UI Symbol", "Noto Color Emoji";
-  --font-stack-mono: SFMono-Regular, Menlo, Monaco, Consolas, "Ubuntu Mono",
-    "Liberation Mono", "Courier New", Courier, monospace;
+  --font-stack-mono: var(--font-plex-mono), SFMono-Regular, Menlo, Monaco,
+    Consolas, "Ubuntu Mono", "Liberation Mono", "Courier New", Courier,
+    monospace;
 }
 
 @supports (font-variation-settings: normal) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -199,7 +199,7 @@ module.exports = {
         DEFAULT: {
           css: {
             code: {
-              padding: `${rem(6)} ${rem(4)}`,
+              padding: `${rem(3)} ${rem(6)}`,
             },
             "code::before": {
               content: "",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,14 @@
 /** @type {import('tailwindcss').Config} */
+
+// From https://github.com/tailwindlabs/tailwindcss-typography/blob/a86e6015694c3435ff6cef84f3dd61b81adf26e1/src/styles.js#L3C1-L18C1
+const round = (num) =>
+  num
+    .toFixed(7)
+    .replace(/(\.[0-9]+?)0+$/, "$1")
+    .replace(/\.0$/, "");
+const rem = (px) => `${round(px / 16)}rem`;
+const em = (px, base) => `${round(px / base)}em`;
+
 module.exports = {
   future: {
     // https://github.com/tailwindlabs/tailwindcss/pull/8394
@@ -165,6 +175,54 @@ module.exports = {
       height: {
         screen: ["100vh", "100dvh"],
       },
+      typography: (theme) => ({
+        custom: {
+          css: {
+            "--tw-prose-body": theme("colors.gray.12"),
+            "--tw-prose-headings": theme("colors.gray.12"),
+            "--tw-prose-lead": theme("colors.gray.12"),
+            "--tw-prose-links": theme("colors.blue.11"),
+            "--tw-prose-bold": theme("colors.gray.12"),
+            "--tw-prose-counters": theme("colors.gray.12"),
+            "--tw-prose-bullets": theme("colors.gray.12"),
+            "--tw-prose-hr": theme("colors.gray.6"),
+            "--tw-prose-quotes": theme("colors.gray.12"),
+            "--tw-prose-quote-borders": theme("colors.gray.6"),
+            "--tw-prose-captions": theme("colors.gray.11"),
+            "--tw-prose-code": theme("colors.crimson.11"),
+            "--tw-prose-pre-code": theme("colors.gray.12"),
+            "--tw-prose-pre-bg": theme("colors.gray.3"),
+            "--tw-prose-th-borders": theme("colors.gray.12"),
+            "--tw-prose-td-borders": theme("colors.gray.6"),
+          },
+        },
+        DEFAULT: {
+          css: {
+            code: {
+              padding: `${rem(6)} ${rem(4)}`,
+            },
+            "code::before": {
+              content: "",
+            },
+            "code::after": {
+              content: "",
+            },
+            details: {
+              marginTop: em(20, 16),
+              marginBottom: em(20, 16),
+            },
+            blockquote: {
+              border: "none",
+            },
+            "blockquote p:first-of-type::before": {
+              content: "",
+            },
+            "blockquote p:last-of-type::after": {
+              content: "",
+            },
+          },
+        },
+      }),
     },
   },
   plugins: [require("@tailwindcss/typography")],


### PR DESCRIPTION
- Customize CSS for Tailwind's typography plugin
- Introduce IBM Plex Mono. Can't use `next/font` for Inter because it doesn't contain the left and right arrow symbols.
